### PR TITLE
Update Dockerfile

### DIFF
--- a/distros/debian/jessie.docu/build/Dockerfile
+++ b/distros/debian/jessie.docu/build/Dockerfile
@@ -52,10 +52,15 @@ RUN echo 'PATH=/opt/arangodb/bin/:${PATH}' >> /etc/profile
 RUN for i in 3.0 3.1 3.2 3.3 devel; do  \
     mkdir -p /tmp/$i; \
     cd /tmp/$i; \
-    for book in AQL HTTP Manual Cookbook; do \
-        curl -O https://raw.githubusercontent.com/arangodb/arangodb/$i/Documentation/Books/${book}/book.json; \
+    for book in AQL HTTP Manual Cookbook Drivers; do \
+        curl --fail -O https://raw.githubusercontent.com/arangodb/arangodb/$i/Documentation/Books/${book}/book.json; \
+        exitcode=$?; \
+        if test $exitcode != 0; then \
+          echo "Failed to fetch book.json for ${i} ${book}, skipping."; \
+          continue; \
+        fi; \
         sed -i "s;@.*@;0;g" book.json; \
-	cat book.json; \
+        cat book.json; \
         gitbook install -g; \
         echo "now its here."; \
         rm book.json; \


### PR DESCRIPTION
- Include Drivers books
- Skip if a book.json can't be retrieved (e.g. 404 because a book doesn't exist in an older version)

curl downloaded a file with content `404: Not Found` before if it didn't exist, which would let `gitbook install` fail because of invalid JSON - which should be harmless because the exit code isn't returned to docker, but we can skip to save some time and print meaningful status messages.

Coupling GSEARCH_ID_* with $book doesn't seem like a good idea as we might replace Google CSE at some point. The versions to download the Gitbook plugins for need to be adjusted manually anyway. Aother option would be to add additional entries to the VERSIONS file, but it would place even more version-independent information into version branches.